### PR TITLE
Visual tweaks

### DIFF
--- a/Condorcet/static/css/main.css
+++ b/Condorcet/static/css/main.css
@@ -3,6 +3,7 @@ body {
   margin: 0 auto;
   background: #eee;
   font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 16px;
   color: #333;
 }
 

--- a/Condorcet/static/css/main.css
+++ b/Condorcet/static/css/main.css
@@ -2,6 +2,7 @@ body {
   width: 100%;
   margin: 0 auto;
   background: #eee;
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
   color: #333;
 }
 

--- a/Condorcet/templates/layout.html
+++ b/Condorcet/templates/layout.html
@@ -24,6 +24,7 @@
       <ul class="right">
         <li><a href="#">Help</a></li>
         <li><a href="{{ contact_url() }}">Contact</a></li>
+        <li><a href="https://login.cern.ch/adfs/ls/?wa=wsignout1.0">Sign out</a></li>
       </ul>
       <div class="left meta">You are signed in as <span class="username">{{ session.user.username }}</span></div>
     </div>


### PR DESCRIPTION
Added a ‘Sign out’ link to the footer and explicitly set the font to a sans-serif one.

I hadn't noticed the font being serif in the past because my browser defaults to sans-serif if one isn't specified.
