### PR TITLE
Loose match

### DIFF
--- a/Condorcet/__init__.py
+++ b/Condorcet/__init__.py
@@ -66,7 +66,13 @@ def set_user():
             ]),
             'admin': 'lhcb-condorcet-voting' in get_environ('ADFS_GROUP')
         }
-    session['user']['author'] = isAuthor(session['user']['fullname'])
+    fuzzyMatch = isAuthor(session['user']['fullname'])
+    print fuzzyMatch
+    if fuzzyMatch:
+        session['user']['author'] = True
+        session['user']['fullname'] = fuzzyMatch
+    else:
+        session['user']['author'] = False
 
 
 def author_required(f):

--- a/Condorcet/__init__.py
+++ b/Condorcet/__init__.py
@@ -67,7 +67,6 @@ def set_user():
             'admin': 'lhcb-condorcet-voting' in get_environ('ADFS_GROUP')
         }
     fuzzyMatch = isAuthor(session['user']['fullname'])
-    print fuzzyMatch
     if fuzzyMatch:
         session['user']['author'] = True
         session['user']['fullname'] = fuzzyMatch

--- a/Condorcet/databases/corrections.txt
+++ b/Condorcet/databases/corrections.txt
@@ -1,2 +1,80 @@
 Helena Graverini -> Elena Graverini
 Timothy Head -> Timothy Daniel Head
+
+# Not present
+Osvaldo Aquines Gutierrez
+Alexander Bien
+Albert Bursche
+Nicola Chiapolini
+Matthew Coombes
+Ian Counts
+Francesco Di Ruscio
+Stephanie Donleavy
+Anatoliy Dovbnya
+
+
+# Preferred name != name 
+Alexander Bondar
+Themistocles Bowcock
+Kazuyoshi Carvalho Akiba
+Shu Faye Cheung
+Samuel Thomas Cunliffe
+
+Bernardo Adeva -> Bernardo | Adeva Andany
+Anthony Affolder -> Tony Affolder
+Michael Alexander -> Michael Thomas | Alexander
+Georgy Alkhazov -> Gueorgui Alkhazov
+Antonio Augusto Alves Jr -> Antonio Augusto |  Alves Junior
+Yasmine Amhis -> Yasmine Sara | Amhis
+Jason Andrews -> Jason Emory | Andrews
+Robert Appleby -> Robert Barrie | Appleby
+John Back -> John James | Back
+Clarissa Baesso -> Clarissa | Azevedo Baesso
+William Barter -> William James | Barter
+Ignacio Bediaga -> Ignacio De Bediaga Hickman
+Ivan Belyaev -> Vanya Belyaev
+Eli Ben-Haim -> Eli Ben Haim
+Marc Olivier Bettler -> Marc Olivier Bettler
+u'Fr\xe9d\xe9ric Blanc' '-> Frederic Henry | Blanc
+Steven Blusk -> Steven Roy Blusk
+Nikolay Bondar -> Nikolai Bondar
+Walter Bonivento -> Walter Marcello | Bonivento
+Svende Braun -> Svende Annelies | Braun
+Thomas Britton -> Thomas Jackson Britton
+Daniel Campora Perez -> Daniel Hugo Campora Perez
+Matthew Charles -> Matthew John | Charles
+Shu-Faye Cheung -> Shu Faye Cheung 
+Gregory Ciezarek -> Gregory Max | Ciezarek
+Harry Cliff -> Harry Victor | Cliff
+Lucian Cojocariu -> Lucian Nicolae | Cojocariu
+Albert Comerma-Montells -> Albert Comerma Montells
+Andrew Cook -> Andrew David | Cook
+Andrew Crocombe -> Andrew Christopher | Crocombe
+Samuel Cunliffe -> Samuel Thomas | Cunliffe
+Robert Currie -> Robert Andrew | Currie
+Jeremy Dalseno -> Jeremy Peter Dalseno
+Jussara De Miranda -> Jussara | Marques De Miranda
+Leandro De Paula -> Leandro | Salazar De Paula
+u'Nicolas D\xe9l\xe9age' -> Nicolas Aurelien | Deleage
+u'Alvaro Dosil Su\xe1rez' -> Alvaro Dosil Suarez
+Alexey Dzyuba -> Aleksei Dziuba
+Semen Eidelman -> Simon Eydelman
+Ulrich Eitschberger -> Ulrich Paul | Eitschberger
+Robert Ekelhof -> Robert Jan Ekelhof
+Christian Elsasser -> Christian Urs Elsasser
+Scott Ely -> Scott Edward | Ely
+Timothy Evans -> Timothy David Evans
+Dianne Ferguson -> Dianne Marion | Ferguson
+Victor Fernandez Albor -> Victor Manuel Fernandez Albor
+Fernando Ferreira Rodrigues -> Fernando Luiz | Ferreira Rodrigues
+Sergey Filippov -> Sergey Philippov  ????
+Oscar Francisco -> Oscar Augusto | De Aguiar Francisco
+Abraham Gallas Torreira -> Abraham Antonio | Gallas Torreira
+
+
+
+
+
+
+
+

--- a/Condorcet/databases/known_mismatches.py
+++ b/Condorcet/databases/known_mismatches.py
@@ -1,0 +1,17 @@
+'''
+Dictionary with known names that are different between
+the author list and the OSS:
+{Name whith OSS: name in authorlist}
+'''
+
+known_mismatches = {
+    'Tony Affolder': 'Anthony Affolder',
+    'Gueorgui Alkhazov': 'Georgy Alkhazov',
+    'Antonio Augusto Alves Junior': 'Antonio Augusto Alves Jr',
+    'Vanya Belyaev': 'Ivan Belyaev',
+    'Nikolai Bondar': 'Nikolay Bondar',
+    'Aleksei Dziuba': 'Alexey Dzyuba',
+    'Simon Eydelman': 'Semen Eidelman',
+    'Sergey Philippov': 'Sergey Filippov',
+    'Elena Graverini': 'Helena Graverini',
+    }

--- a/Condorcet/templates/alreadyVoted.html
+++ b/Condorcet/templates/alreadyVoted.html
@@ -3,6 +3,9 @@
 {% block body %}
     <h2>You have already voted</h2>
 
-    <p>Each LHCb author is allowed a single unalterable vote, and there is already a vote registered for {{ session.user.fullname }}. If you believe that you have not yet voted, please <a href="{{ contact_url() }}">contact the membership committee</a>.</p>
+    <p>Each LHCb author is allowed a single unalterable vote, and there is
+    already a vote registered for {{ session.user.fullname }}. If you believe
+    that you have not yet voted, please <a href="{{ contact_url() }}">contact
+    the admins</a>.</p>
     <p><a href='results'>Click here</a> to see the election results.</p>
 {% endblock %}

--- a/Condorcet/templates/notAuthor.html
+++ b/Condorcet/templates/notAuthor.html
@@ -5,7 +5,7 @@
     <p>The LHCb constitution only allows LHCb collaborators who are on the author list to vote in the Physics Coordinator elections, and so you are unable to vote.</p>
     <p>Your name is <span class="important">{{session.user.fullname}}</span> and you do not seems to
     appear in the <a href={{ url_for('download', filename=authorList) }} download> author list </a></p>
-    <p>If you think this is incorrect, please <a href="{{ contact_url() }}">contact the membership committee</a>.</p>
+    <p>If you think this is incorrect, please <a href="{{ contact_url() }}">contact the admins</a>.</p>
 
 {% endblock %}
 

--- a/Condorcet/verifyAuthors.py
+++ b/Condorcet/verifyAuthors.py
@@ -47,11 +47,17 @@ def isAuthor(fullname, authors_file=None):
 
     if fullname_norm in list_authors_norm:
         return fullname
-    else:
-        parts = set(fullname_norm.split())
-        for name, name_norm in zip(list_authors, list_authors_norm):
-            if (set(name_norm.split()).issubset(parts) or
-               parts.issubset(set(name_norm.split()))):
-                return name
 
+    parts = set(fullname_norm.split())
+    for name, name_norm in zip(list_authors, list_authors_norm):
+        if (set(name_norm.split()).issubset(parts) or
+           parts.issubset(set(name_norm.split()))):
+            return name
+
+    gg = {}
+    execfile(os.path.join(app.config['DB_DIR'], 'known_mismatches.py'), gg)
+    try:
+        return gg['known_mismatches'][fullname]
+    except KeyError:
+        pass
     return False

--- a/Condorcet/verifyAuthors.py
+++ b/Condorcet/verifyAuthors.py
@@ -2,7 +2,7 @@ import xml.etree.ElementTree
 import os
 from Condorcet import app
 from Condorcet.updateConfig import getConfig
-from fuzzywuzzy import process
+import unicodedata
 
 
 def default_authors_file():
@@ -24,6 +24,15 @@ def listAuthors(authors_file=default_authors_file()):
     return [' '.join([child[0].text, child[1].text]) for child in root[4]]
 
 
+def str_normalize(string):
+    norm1 = string.strip().lower().replace('-', ' ')
+    try:
+        return ''.join((c for c in unicodedata.normalize('NFD', norm1)
+                        if unicodedata.category(c) != 'Mn'))
+    except TypeError:
+        return norm1
+
+
 def isAuthor(fullname, authors_file=None):
     """
     Match using fuzzy logic and return fullname as appear in the
@@ -31,10 +40,18 @@ def isAuthor(fullname, authors_file=None):
     """
     if authors_file is None:
         authors_file = default_authors_file()
-    matches = process.extract(fullname, listAuthors(authors_file=authors_file),
-                              limit=3)
-    if (matches[0][1] > 80 and
-       (matches[0][1] - matches[1][1]) > (matches[1][1] - matches[2][1])):
-        return matches[0][0]
+
+    list_authors = listAuthors(authors_file=authors_file)
+    list_authors_norm = [str_normalize(i) for i in list_authors]
+    fullname_norm = str_normalize(fullname)
+
+    if fullname_norm in list_authors_norm:
+        return fullname
     else:
-        return False
+        parts = set(fullname_norm.split())
+        for name, name_norm in zip(list_authors, list_authors_norm):
+            if (set(name_norm.split()).issubset(parts) or
+               parts.issubset(set(name_norm.split()))):
+                return name
+
+    return False

--- a/Condorcet/verifyAuthors.py
+++ b/Condorcet/verifyAuthors.py
@@ -2,6 +2,7 @@ import xml.etree.ElementTree
 import os
 from Condorcet import app
 from Condorcet.updateConfig import getConfig
+from fuzzywuzzy import process
 
 
 def default_authors_file():
@@ -24,6 +25,16 @@ def listAuthors(authors_file=default_authors_file()):
 
 
 def isAuthor(fullname, authors_file=None):
+    """
+    Match using fuzzy logic and return fullname as appear in the
+    voters' database
+    """
     if authors_file is None:
         authors_file = default_authors_file()
-    return fullname in listAuthors(authors_file=authors_file)
+    matches = process.extract(fullname, listAuthors(authors_file=authors_file),
+                              limit=3)
+    if (matches[0][1] > 80 and
+       (matches[0][1] - matches[1][1]) > (matches[1][1] - matches[2][1])):
+        return matches[0][0]
+    else:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,3 @@ MarkupSafe==0.23
 SQLAlchemy==0.9.9
 Werkzeug==0.10.1
 argparse==1.3.0
-python-Levenshtein==0.12.0
-fuzzywuzzy==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ MarkupSafe==0.23
 SQLAlchemy==0.9.9
 Werkzeug==0.10.1
 argparse==1.3.0
+python-Levenshtein==0.12.0
+fuzzywuzzy==0.5.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,7 +36,7 @@ TEST_ENVIRON_NOT_AUTHOR = {
 
 def mocked_isAuthor(fullname, authors_file=''):
     # Assume the only author is TEST_FULLNAME
-    return fullname == TEST_FULLNAME
+    return fullname if fullname == TEST_FULLNAME else False
 
 
 def mocked_hasVoted(fullname):

--- a/tests/test_verify_authors.py
+++ b/tests/test_verify_authors.py
@@ -58,7 +58,7 @@ AUTHORS = [
 # List of names that should not be present in the above XML file
 NOT_AUTHORS = [
     'a',
-    'Given4 Family4'
+    'Pollo4 Family4'
 ]
 
 


### PR DESCRIPTION
Other attempt to solve issue #23:
instead of using a black-box library I just accept defined simple cases:
- one of the two full names is a subset of the other (eg. 'Timothy Head' subset 'Timothy Daniel Head')
- ignore difference in accents, lower cases

All the spelling mistakes or different spelling for Russian names are still a problem but I cannot solve it without allowing wrong matches to be made (eg. Atlas' member Liqing Zhang being confused with LHCb's member Liming Zhang).

I guess that the simpler solution is or to change the database or to "hard code" known differences
